### PR TITLE
Dockerfile: adding go1.15.6 and brotli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN dpkg --add-architecture i386 \
     clang \
     m4 file \
     wget git \
+    brotli \
  && apt clean \
  && rm -rf /var/lib/apt/lists
 

--- a/Dockerfile.1.15.6
+++ b/Dockerfile.1.15.6
@@ -1,8 +1,8 @@
 ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:temp as image
 
-RUN GOLANG_VERSION=1.15.5 \
- && DIGEST='9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d' \
+RUN GOLANG_VERSION=1.15.6 \
+ && DIGEST='3918e6cc85e7eaaa6f859f1bdbaac772e7a825b0eb423c63d3ae68b21f84b844' \
  && wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && echo "${DIGEST} *go.tgz" | sha256sum -c - \
  &&	tar -C /usr/local -xzf go.tgz \
@@ -19,7 +19,7 @@ RUN mkdir /tmp/tools \
  && go build -o /go/bin/goreleaser -v \
  && : "Install golangci-lint" \
  && cd /tmp/tools \
- && git clone https://github.com/golangci/golangci-lint -b v1.32.2 \
+ && git clone https://github.com/golangci/golangci-lint -b v1.33.0 \
  && cd golangci-lint \
  && go build -o /go/bin/golangci-lint -v ./cmd/golangci-lint \
  && : "Clean up the layer" \


### PR DESCRIPTION
This PR commits the v1.15.6 docker change as well as the support to handle brotli files within these containers.