### PR TITLE
add darwin/arm64 target to the cc file

### DIFF
--- a/cc
+++ b/cc
@@ -76,6 +76,14 @@ darwin-amd64-c++)
 	export CXX=o64-clang++
 	exec "${CXX}" "$@"
 ;;
+darwin-arm64-cc)
+	export CC=o64-clang
+	exec "${CC}" "$@"
+;;
+darwin-arm64-c++)
+	export CXX=o64-clang++
+	exec "${CXX}" "$@"
+;;
 darwin-*-go)
 ;;
 ## Freebsd

--- a/test.bash
+++ b/test.bash
@@ -50,6 +50,7 @@ outputs=(
 	[linux_arm64]="ELF.*ARM.*aarch64.*static.*, stripped"
 	[darwin_386]="Mach-O i386"
 	[darwin_amd64]="Mach-O 64"
+	[darwin_arm64]="Mach-O 64"
 	[windows_386]="PE32[^+]"
 	[windows_amd64]="PE32\\+"
 	[freebsd_amd64]="x86-64.*FreeBSD.*static.*, stripped"


### PR DESCRIPTION
This is a fix for failing builds for darwin/arm64.