### PR TITLE
Dockerfile: update to go1.16.6

### DIFF
--- a/Dockerfile.1.16.6
+++ b/Dockerfile.1.16.6
@@ -1,8 +1,8 @@
 ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:temp as image
 
-RUN GOLANG_VERSION=1.16 \
- && DIGEST='013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2' \
+RUN GOLANG_VERSION=1.16.6 \
+ && DIGEST='be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d' \
  && wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
  && echo "${DIGEST} *go.tgz" | sha256sum -c - \
  &&	tar -C /usr/local -xzf go.tgz \
@@ -19,7 +19,7 @@ RUN mkdir /tmp/tools \
  && go build -o /go/bin/goreleaser -v \
  && : "Install golangci-lint" \
  && cd /tmp/tools \
- && git clone https://github.com/golangci/golangci-lint -b v1.37.0 \
+ && git clone https://github.com/golangci/golangci-lint -b v1.41.1 \
  && cd golangci-lint \
  && go build -o /go/bin/golangci-lint -v ./cmd/golangci-lint \
  && : "Clean up the layer" \


### PR DESCRIPTION
Bump to go 1.16.6 and golangci-lint 1.41.1