### PR TITLE
Update Dockerfile for Go 1.17.x to 1.17.12

### DIFF
--- a/Dockerfile.1.17.12
+++ b/Dockerfile.1.17.12
@@ -2,7 +2,7 @@ ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:temp as image
 
 RUN GOLANG_VERSION=1.17.12 \
-    && DIGEST='TODO(artur): fill this in on Tuesday' \
+    && DIGEST='6e5203fbdcade4aa4331e441fd2e1db8444681a6a6c72886a37ddd11caa415d4' \
     && wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
     && echo "${DIGEST} *go.tgz" | sha256sum -c - \
     &&	tar -C /usr/local -xzf go.tgz \

--- a/Dockerfile.1.17.12
+++ b/Dockerfile.1.17.12
@@ -1,14 +1,14 @@
 ARG IMAGE_NAME
 FROM ${IMAGE_NAME}:temp as image
 
-RUN GOLANG_VERSION=1.17.5 \
- && DIGEST='bd78114b0d441b029c8fe0341f4910370925a4d270a6a590668840675b0c653e' \
- && wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
- && echo "${DIGEST} *go.tgz" | sha256sum -c - \
- &&	tar -C /usr/local -xzf go.tgz \
- && rm go.tgz \
- && echo PATH: $PATH \
- && go version
+RUN GOLANG_VERSION=1.17.12 \
+    && DIGEST='TODO(artur): fill this in on Tuesday' \
+    && wget -O go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
+    && echo "${DIGEST} *go.tgz" | sha256sum -c - \
+    &&	tar -C /usr/local -xzf go.tgz \
+    && rm go.tgz \
+    && echo PATH: $PATH \
+    && go version
 
 FROM image as onbuild
 
@@ -18,7 +18,7 @@ ONBUILD ARG REPOSITORY
 ONBUILD WORKDIR /go/src/${REPOSITORY}/
 ONBUILD ARG CGO_ENABLED
 ONBUILD ENV CGO_ENABLED=${CGO_ENABLED} \
-            GO111MODULE=on
+    GO111MODULE=on
 ONBUILD COPY go.mod .
 ONBUILD COPY go.sum .
 ONBUILD RUN go mod download


### PR DESCRIPTION
This should be merged on Tuesday (12.07.2022).