### PR TITLE
cc: remove explicit -s -w

### DIFF
--- a/cc
+++ b/cc
@@ -141,10 +141,11 @@ while (( $# )); do
 	fi
 	shift
 done
-if [ "$set_flags" = 0 ]; then
-	echo /usr/local/go/bin/go $SUBCMD -ldflags "-s -w ${LDFLAGS:-}" "${arr[@]}"
-	exec /usr/local/go/bin/go $SUBCMD -ldflags "-s -w ${LDFLAGS:-}" "${arr[@]}"
-else
-	echo /usr/local/go/bin/go $SUBCMD "${arr[@]}"
-	exec /usr/local/go/bin/go $SUBCMD "${arr[@]}"
+
+if [ "$set_flags" = 0 ] && [ -n "$LDFLAGS" ]; then
+   arr[${#arr[@]}]="-ldflags"
+   arr[${#arr[@]}]="$LDFLAGS"
 fi
+
+echo /usr/local/go/bin/go $SUBCMD "${arr[@]}"
+exec /usr/local/go/bin/go $SUBCMD "${arr[@]}"


### PR DESCRIPTION
Today `-s -w ` are added as default. (if no -ldflags are used).

I believe it's better to make them explicit.

Existing logic:

 1. If -ldflags or -ldflags= is given--> use both flag and env variable (set_flags=1) and '-w -s'
 2. If not, ignore even the $LDFLAGS

New logic:

 1. If `-ldflags[=]` is given --> use it (flag + env variable)
 2. If LDFLAGS is set, but it's not used during flag parsing--> use it
