### PR TITLE
cc: revert LDFLAGS logic change

### DIFF
--- a/cc
+++ b/cc
@@ -117,11 +117,10 @@ while (( $# )); do
 	fi
 	shift
 done
-
-if [ "$set_flags" = 0 ] && [ -n "$LDFLAGS" ]; then
-   arr[${#arr[@]}]="-ldflags"
-   arr[${#arr[@]}]="$LDFLAGS"
+if [ "$set_flags" = 0 ]; then
+	echo /usr/local/go/bin/go $SUBCMD -ldflags "${LDFLAGS:-}" "${arr[@]}"
+	exec /usr/local/go/bin/go $SUBCMD -ldflags "${LDFLAGS:-}" "${arr[@]}"
+else
+	echo /usr/local/go/bin/go $SUBCMD "${arr[@]}"
+	exec /usr/local/go/bin/go $SUBCMD "${arr[@]}"
 fi
-
-echo /usr/local/go/bin/go $SUBCMD "${arr[@]}"
-exec /usr/local/go/bin/go $SUBCMD "${arr[@]}"


### PR DESCRIPTION
This mostly reverts commit 2d24085cfb81e705c7757e4b7e9f082f1e01e268.

This preserves the old LDFLAGS logic, however still removes -s -w.