### PR TITLE
Dockerfile: cleanup tmp directory

### DIFF
--- a/Dockerfile.1.20.14
+++ b/Dockerfile.1.20.14
@@ -8,6 +8,9 @@ RUN GOLANG_VERSION=1.20.14 \
     &&	tar -C /usr/local -xzf go.tgz \
     && rm go.tgz \
     && echo PATH: $PATH \
+    && RUN /bin/bash -uec rm -rf /tmp/.cache \
+    && RUN /bin/bash -uec rm -rf /tmp/.config \
+    && RUN /bin/bash -uec rm -rf /tmp/.wget-hsts \
     && go version
 
 FROM image AS onbuild

--- a/Dockerfile.1.21.13
+++ b/Dockerfile.1.21.13
@@ -8,6 +8,9 @@ RUN GOLANG_VERSION=1.21.13 \
     &&	tar -C /usr/local -xzf go.tgz \
     && rm go.tgz \
     && echo PATH: $PATH \
+    && RUN /bin/bash -uec rm -rf /tmp/.cache \
+    && RUN /bin/bash -uec rm -rf /tmp/.config \
+    && RUN /bin/bash -uec rm -rf /tmp/.wget-hsts \
     && go version
 
 FROM image AS onbuild

--- a/Dockerfile.1.22.11
+++ b/Dockerfile.1.22.11
@@ -8,7 +8,11 @@ RUN GOLANG_VERSION=1.22.11 \
     &&	tar -C /usr/local -xzf go.tgz \
     && rm go.tgz \
     && echo PATH: $PATH \
+    && RUN /bin/bash -uec rm -rf /tmp/.cache \
+    && RUN /bin/bash -uec rm -rf /tmp/.config \
+    && RUN /bin/bash -uec rm -rf /tmp/.wget-hsts \
     && go version
+
 
 FROM image AS onbuild
 

--- a/Dockerfile.1.23.8
+++ b/Dockerfile.1.23.8
@@ -8,6 +8,9 @@ RUN GOLANG_VERSION=1.23.8 \
     &&	tar -C /usr/local -xzf go.tgz \
     && rm go.tgz \
     && echo PATH: $PATH \
+    && RUN /bin/bash -uec rm -rf /tmp/.cache \
+    && RUN /bin/bash -uec rm -rf /tmp/.config \
+    && RUN /bin/bash -uec rm -rf /tmp/.wget-hsts \
     && go version
 
 FROM image AS onbuild

--- a/Dockerfile.1.24.2
+++ b/Dockerfile.1.24.2
@@ -8,6 +8,9 @@ RUN GOLANG_VERSION=1.24.2 \
     &&	tar -C /usr/local -xzf go.tgz \
     && rm go.tgz \
     && echo PATH: $PATH \
+    && RUN /bin/bash -uec rm -rf /tmp/.cache \
+    && RUN /bin/bash -uec rm -rf /tmp/.config \
+    && RUN /bin/bash -uec rm -rf /tmp/.wget-hsts \
     && go version
 
 FROM image AS onbuild


### PR DESCRIPTION
Our build failed with:

```
/usr/local/go/bin/go build -ldflags  -linkmode external -extldflags "-static" -race -o /.../bin/storagenode storj.io/storj/cmd/storagenode

failed to initialize build cache at /tmp/.cache/go-build: mkdir /tmp/.cache/go-build: permission denied
```

Looks that we have a few directories in /tmp which are created by user root. Couldn't be used by regular user.

Let's delete them.
